### PR TITLE
Added getters and setters for activities and relationships in Log_Skeleton class

### DIFF
--- a/src/components/logic/log_skeleton.py
+++ b/src/components/logic/log_skeleton.py
@@ -84,11 +84,11 @@ class Log_Skeleton:
         activitiy pairs of that relationship.
         """
         res = {}
-
+        extension = self.include_trace_extensions  # For the sake of flake...
         for r in self.working_relationships:
             r_instance = self.relationships[r](self.log, self.all_activities,
                                                self.noise_threshold,
-                                               self.include_trace_extensions)
+                                               include_extenstions=extension)
 
             res[r] = r_instance.apply()
         return res

--- a/src/components/logic/log_skeleton.py
+++ b/src/components/logic/log_skeleton.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     path = os.path.join(
         os.path.dirname(__file__), '../../../res/logs/running-example.xes')
 
-    log_and_activset = importer.import_file(path)
+    log_and_activset = importer.import_file(path, [], [])
     log = log_and_activset[0]
     activset = log_and_activset[1]
 
@@ -110,5 +110,5 @@ if __name__ == "__main__":
             Parameters.NOISE_THRESHOLD: 0})
     print(skeleton)
     model = Log_Skeleton(log, activset, 0.1)
-    model.set_activities(['always_before', 'counter'])
+    model.set_working_relationships(['always_before', 'counter'])
     print(model.apply())

--- a/src/components/logic/log_skeleton.py
+++ b/src/components/logic/log_skeleton.py
@@ -23,14 +23,15 @@ class Log_Skeleton:
         """
         self.relationships = {
             # Dictionary contains string representation of all classes
-            rel.Always_Before: 'always_before',
-            rel.AlwaysAfter: 'always_after',
-            rel.Equivalence: 'equivalence',
-            rel.Never_Together: 'never_together',
-            rel.Next_Both_Ways: 'next_both_ways',
-            rel.Next_One_Way: 'next_one_way',
-            rel.Counter: 'counter',
+            'always_before': rel.Always_Before,
+            'always_after': rel.AlwaysAfter,
+            'equivalence': rel.Equivalence,
+            'never_together': rel.Never_Together,
+            'next_both_ways': rel.Next_Both_Ways,
+            'next_one_way': rel.Next_One_Way,
+            'counter': rel.Counter,
         }
+        self.working_relationships = set(list(self.relationships.keys()))
         self.all_activities = all_activities
         self.include_trace_extensions = include_trace_extensions
 
@@ -38,6 +39,42 @@ class Log_Skeleton:
 
         # Noise threshold only between 0 and 1
         self.noise_threshold = min(1.0, max(0.0, noise_threshold))
+
+    def set_activities(self, activities):
+        """Choose which activities to include in the log skeleton.
+
+        Parameters:
+        activities : A set of activities
+        """
+        self.all_activities = activities
+
+    def get_activities(self):
+        """Return the current set of activities"""
+        return self.all_activities
+
+    def set_working_relationships(self, working_relationships):
+        """Choose working set for the relationship
+
+        Parameters:
+        working_relationships: A set or list of relationships as string
+
+        Possible relationships:
+        'always_before'
+        'always_after'
+        'equivalence'
+        'never_together'
+        'next_both_ways'
+        'next_one_way'
+        'counter'
+        """
+        self.working_relationships = set()
+        for r in working_relationships:
+            if(r in self.relationships):
+                self.working_relationships.add(r)
+
+    def get_working_relationships(self):
+        """Return current working set of relationships """
+        return self.working_relationships
 
     def apply(self):
         """Return the log skeleton model as a dictionary.
@@ -48,12 +85,12 @@ class Log_Skeleton:
         """
         res = {}
 
-        for r in self.relationships:
-            r_instance = r(self.log, self.all_activities,
+        for r in self.working_relationships:
+            r_instance = self.relationships[r](self.log, self.all_activities,
                            self.noise_threshold,
                            include_extenstions=self.include_trace_extensions)
 
-            res[self.relationships[r]] = r_instance.apply()
+            res[r] = r_instance.apply()
         return res
 
 
@@ -63,7 +100,7 @@ if __name__ == "__main__":
     path = os.path.join(
         os.path.dirname(__file__), '../../../res/logs/running-example.xes')
 
-    log_and_activset = importer.import_file(path)
+    log_and_activset = importer.import_file(path, [], [])
     log = log_and_activset[0]
     activset = log_and_activset[1]
 
@@ -73,4 +110,5 @@ if __name__ == "__main__":
             Parameters.NOISE_THRESHOLD: 0})
     print(skeleton)
     model = Log_Skeleton(log, activset, 0.1)
+    model.set_activities(['always_before', 'counter'])
     print(model.apply())

--- a/src/components/logic/log_skeleton.py
+++ b/src/components/logic/log_skeleton.py
@@ -23,14 +23,15 @@ class Log_Skeleton:
         """
         self.relationships = {
             # Dictionary contains string representation of all classes
-            rel.Always_Before: 'always_before',
-            rel.AlwaysAfter: 'always_after',
-            rel.Equivalence: 'equivalence',
-            rel.Never_Together: 'never_together',
-            rel.Next_Both_Ways: 'next_both_ways',
-            rel.Next_One_Way: 'next_one_way',
-            rel.Counter: 'counter',
+            'always_before': rel.Always_Before,
+            'always_after': rel.AlwaysAfter,
+            'equivalence': rel.Equivalence,
+            'never_together': rel.Never_Together,
+            'next_both_ways': rel.Next_Both_Ways,
+            'next_one_way': rel.Next_One_Way,
+            'counter': rel.Counter,
         }
+        self.working_relationships = set(list(self.relationships.keys()))
         self.all_activities = all_activities
         self.include_trace_extensions = include_trace_extensions
 
@@ -38,6 +39,42 @@ class Log_Skeleton:
 
         # Noise threshold only between 0 and 1
         self.noise_threshold = min(1.0, max(0.0, noise_threshold))
+
+    def set_activities(self, activities):
+        """Choose which activities to include in the log skeleton.
+
+        Parameters:
+        activities : A set of activities
+        """
+        self.all_activities = activities
+
+    def get_activities(self):
+        """Return the current set of activities"""
+        return self.all_activities
+
+    def set_working_relationships(self, working_relationships):
+        """Choose working set for the relationship
+
+        Parameters:
+        working_relationships: A set or list of relationships as string
+
+        Possible relationships:
+        'always_before'
+        'always_after'
+        'equivalence'
+        'never_together'
+        'next_both_ways'
+        'next_one_way'
+        'counter'
+        """
+        self.working_relationships = set()
+        for r in working_relationships:
+            if(r in self.relationships):
+                self.working_relationships.add(r)
+
+    def get_working_relationships(self):
+        """Return current working set of relationships """
+        return self.working_relationships
 
     def apply(self):
         """Return the log skeleton model as a dictionary.
@@ -48,7 +85,7 @@ class Log_Skeleton:
         """
         res = {}
 
-        for r in self.relationships:
+        for r in self.working_relationships:
             r_instance = r(self.log, self.all_activities,
                            self.noise_threshold,
                            include_extenstions=self.include_trace_extensions)
@@ -73,4 +110,5 @@ if __name__ == "__main__":
             Parameters.NOISE_THRESHOLD: 0})
     print(skeleton)
     model = Log_Skeleton(log, activset, 0.1)
+    model.set_activities(['always_before', 'counter'])
     print(model.apply())


### PR DESCRIPTION
Log_Skeleton now provides a bunch of getter and setter methods:

set_activities: Choose which activities to be included in the model

get_activities: Return the current set of activities

set_working_relationships: Choose which relationships to be included in the model (called "working relationships"). They are represented by strings.

get_working_relationships: Return current set of working relationships